### PR TITLE
Fix for repository not found on windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ version = "1.0"
 // In this section you declare where to find the dependencies of your project
 
 import org.ajoberstar.grgit.*
-def repo = Grgit.open('.')
+def repo = Grgit.open(System.getProperty("user.dir"))
 jar {
 	manifest {
         attributes("Built-By": System.getProperty("user.name"))


### PR DESCRIPTION
'.'  refers to Gradle directory and hence throws an error


* What went wrong:
A problem occurred evaluating root project 'sample-gradle-git'.
> repository not found: ~\.gradle\daemon\6.5\.git